### PR TITLE
Removed Python 2.7 and 3.4; Added 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install -r requirements.txt
   - pip install coverage mock coveralls

--- a/README.rst
+++ b/README.rst
@@ -111,4 +111,4 @@ MIT. See `LICENSE`_ for more details.
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/usps-api.svg?style=flat-square
     :target: https://pypi.python.org/pypi/usps-api
-    :alt: Python 2.7, 3.4, 3.5, 3.6
+    :alt: Python 3.5, 3.6, 3.7, 3.8

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='usps-api',
-    version='0.3',
+    version='0.4',
     author='Tobin Brown',
     author_email='tobin@brobin.me',
     packages=['usps'],
@@ -21,9 +21,10 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing',
         'Topic :: Utilities',


### PR DESCRIPTION
@Brobin I also bumped the version (not sure if I should do this or not) due to "technically dropping" python 2.7 support. Mostly just wanted 3.7 and 3.8 on the test suite, as I've been running 3.8 with this library for a while and it has already been working anyway.