### PR TITLE
Optional parameter added in AddressValidate class

### DIFF
--- a/usps/usps.py
+++ b/usps/usps.py
@@ -51,8 +51,9 @@ class USPSApi(object):
 
 class AddressValidate(object):
 
-    def __init__(self, usps, address):
+    def __init__(self, usps, address, revision=False):
         xml = etree.Element('AddressValidateRequest', {'USERID': usps.api_user_id})
+        entree.SubElement(xml, "Revision").text = str(int(revision))
         _address = etree.SubElement(xml, 'Address', {'ID': '0'})
         address.add_to_xml(_address, prefix='', validate=True)
 


### PR DESCRIPTION
This optional parameter will allow us to get additional information on AddressValidate response. This is helpful if we want to know if an address is commercial or not. 
